### PR TITLE
feat: combine auctionSurplus and transferSurplus in one method

### DIFF
--- a/docs/src/detailed/modules/acc_engine.md
+++ b/docs/src/detailed/modules/acc_engine.md
@@ -45,7 +45,7 @@ The Accounting Engine serves as the system's financial management hub, overseein
 - **Surplus Auction House**: Is called to start surplus auctions.
 - **Debt Auction House**: Is called to start debt auctions.
 - `postSettlementSurplusDrain`: Address to which surplus is sent following Global Settlement.
-- `surplusIsTransferred`: Whether the surplus should be either auctioned off or transferred.
+- `surplusIsTransferred`: Percent of the surplus that should be transfered vs auctioned off.
 - `surplusDelay`: Time lag before the surplus becomes eligible for either auction or transfer.
 - `popDebtDelay`: Time interval after which debt can be popped from the time-sensitive queue.
 - `disableCooldown`: The waiting period following Global Settlement, after which any remaining surplus should be transferred.

--- a/script/GoerliParams.s.sol
+++ b/script/GoerliParams.s.sol
@@ -21,7 +21,7 @@ abstract contract GoerliParams is Contracts, Params {
     });
 
     _accountingEngineParams = IAccountingEngine.AccountingEngineParams({
-      surplusIsTransferred: 0, // surplus is auctioned
+      surplusIsTransferred: 0, // percent of surplus that is transfered
       surplusDelay: 1800, // 30 minutes
       popDebtDelay: 1800, // 30 minutes
       disableCooldown: 3 days,

--- a/script/MainnetParams.s.sol
+++ b/script/MainnetParams.s.sol
@@ -12,7 +12,7 @@ abstract contract MainnetParams is Contracts, Params {
     });
 
     _accountingEngineParams = IAccountingEngine.AccountingEngineParams({
-      surplusIsTransferred: 0, // surplus is auctioned
+      surplusIsTransferred: 0, // percent of surplus that is transfered
       surplusDelay: 1 days,
       popDebtDelay: 1 days,
       disableCooldown: 3 days,

--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -193,7 +193,7 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
 
   /// @inheritdoc IAccountingEngine
   function auctionSurplus() external returns (uint256 _id) {
-    if (_params.surplusIsTransferred == 1) revert AccEng_SurplusAuctionDisabled();
+    if (_params.surplusIsTransferred == 100) revert AccEng_SurplusAuctionDisabled();
     if (_params.surplusAmount == 0) revert AccEng_NullAmount();
     if (block.timestamp < lastSurplusTime + _params.surplusDelay) revert AccEng_SurplusCooldown();
 

--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -205,23 +205,23 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
       revert AccEng_InsufficientSurplus();
     }
 
-    _id = surplusAuctionHouse.startAuction({_amountToSell: _params.surplusAmount * (100 - surplusIsTransferred) / 100, _initialBid: 0});
+    _id = surplusAuctionHouse.startAuction({_amountToSell: _params.surplusAmount * (100 - _params.surplusIsTransferred) / 100, _initialBid: 0});
 
     lastSurplusTime = block.timestamp;
-    emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - surplusIsTransferred) / 100);
+    emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - _params.surplusIsTransferred) / 100);
 
     //Transfer remaining surplus percentage
-    if(surplusIsTransferred > 0){
+    if(_params.surplusIsTransferred > 0){
       if (extraSurplusReceiver == address(0)) revert AccEng_NullSurplusReceiver();
 
       safeEngine.transferInternalCoins({
         _source: address(this),
         _destination: extraSurplusReceiver,
-        _rad: _params.surplusAmount * surplusIsTransferred / 100
+        _rad: _params.surplusAmount * _params.surplusIsTransferred / 100
       });
 
       lastSurplusTime = block.timestamp;
-      emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * surplusIsTransferred / 100);
+      emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * _params.surplusIsTransferred / 100);
     }
   }
 
@@ -245,18 +245,18 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
     safeEngine.transferInternalCoins({
       _source: address(this),
       _destination: extraSurplusReceiver,
-      _rad: _params.surplusAmount * surplusIsTransferred / 100
+      _rad: _params.surplusAmount * _params.surplusIsTransferred / 100
     });
 
     lastSurplusTime = block.timestamp;
-    emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * surplusIsTransferred / 100);
+    emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * _params.surplusIsTransferred / 100);
 
     //auction remaining surplus percentage
-    if(surplusIsTransferred < 100){
-      uint _id = surplusAuctionHouse.startAuction({_amountToSell: _params.surplusAmount * (100 - surplusIsTransferred) / 100, _initialBid: 0});
+    if(_params.surplusIsTransferred < 100){
+      uint _id = surplusAuctionHouse.startAuction({_amountToSell: _params.surplusAmount * (100 - _params.surplusIsTransferred) / 100, _initialBid: 0});
 
       lastSurplusTime = block.timestamp;
-      emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - surplusIsTransferred) / 100);
+      emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - _params.surplusIsTransferred) / 100);
     }
   }
 

--- a/src/contracts/AccountingEngine.sol
+++ b/src/contracts/AccountingEngine.sol
@@ -210,7 +210,19 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
     lastSurplusTime = block.timestamp;
     emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - surplusIsTransferred) / 100);
 
-    if(surplusIsTransferred > 0) transferExtraSurplus();
+    //Transfer remaining surplus percentage
+    if(surplusIsTransferred > 0){
+      if (extraSurplusReceiver == address(0)) revert AccEng_NullSurplusReceiver();
+
+      safeEngine.transferInternalCoins({
+        _source: address(this),
+        _destination: extraSurplusReceiver,
+        _rad: _params.surplusAmount * surplusIsTransferred / 100
+      });
+
+      lastSurplusTime = block.timestamp;
+      emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * surplusIsTransferred / 100);
+    }
   }
 
   // Extra surplus transfers/surplus auction alternative
@@ -238,6 +250,14 @@ contract AccountingEngine is Authorizable, Modifiable, Disableable, IAccountingE
 
     lastSurplusTime = block.timestamp;
     emit TransferSurplus(extraSurplusReceiver, _params.surplusAmount * surplusIsTransferred / 100);
+
+    //auction remaining surplus percentage
+    if(surplusIsTransferred < 100){
+      uint _id = surplusAuctionHouse.startAuction({_amountToSell: _params.surplusAmount * (100 - surplusIsTransferred) / 100, _initialBid: 0});
+
+      lastSurplusTime = block.timestamp;
+      emit AuctionSurplus(_id, 0, _params.surplusAmount * (100 - surplusIsTransferred) / 100);
+    }
   }
 
   // --- Shutdown ---

--- a/src/interfaces/IAccountingEngine.sol
+++ b/src/interfaces/IAccountingEngine.sol
@@ -143,7 +143,7 @@ interface IAccountingEngine is IAuthorizable, IDisableable, IModifiable {
 
   /**
    * @notice Getter for the unpacked contract parameters struct
-   * @return _surplusIsTransferred Whether the system transfers surplus instead of auctioning it [0/1]
+   * @return _surplusIsTransferred percent of the Surplus the system transfers instead of auctioning [0/1]
    * @return _surplusDelay Amount of seconds between surplus actions
    * @return _popDebtDelay Amount of seconds after which debt can be popped from debtQueue
    * @return _disableCooldown Amount of seconds to wait (post settlement) until surplus can be drained


### PR DESCRIPTION
## Motivation
Selling system coin from surplus creates too much sell pressure and prevents the DAO/governor from accruing any fees in system coin. The stablecoin would be more stable if a percent of fees went to a treasury instead of being sold.

# changes
Changes are kept simple by not changing function names or removing any functions, even if it adds some redundancy. 

1. Either `transferExtraSurplus()` or `auctionSurplus()` can be used to kick off an auction AND transfer some surplus
2. `surplusIsTransferred` parameter is no longer boolean, but is a percentage from 0-100 of what percent of surplus is to be transfered to the `extraSurplusReceiver` vs auctioned. 
3. the same checks for if the system has enough surplus to send should always be made
4. notes in the params script files are updated