### PR TITLE
increase precision by doing wmul first

### DIFF
--- a/src/contracts/oracles/DenominatedOracle.sol
+++ b/src/contracts/oracles/DenominatedOracle.sol
@@ -62,7 +62,7 @@ contract DenominatedOracle is IBaseOracle, IDenominatedOracle {
     (uint256 _denominationPriceSourceValue, bool _denominationPriceSourceValidity) =
       denominationPriceSource.getResultWithValidity();
 
-    if (INVERTED) {
+    if (inverted) {
       if (_priceSourceValue == 0) return (0, false);
       _result = WAD.wmul(_denominationPriceSourceValue).wdiv(_priceSourceValue);
     } else {

--- a/src/contracts/oracles/DenominatedOracle.sol
+++ b/src/contracts/oracles/DenominatedOracle.sol
@@ -69,7 +69,6 @@ contract DenominatedOracle is IBaseOracle, IDenominatedOracle {
       _result = _priceSourceValue.wmul(_denominationPriceSourceValue);
     }
 
-    _result = _priceSourceValue.wmul(_denominationPriceSourceValue);
     _validity = _priceSourceValidity && _denominationPriceSourceValidity;
   }
 

--- a/src/contracts/oracles/DenominatedOracle.sol
+++ b/src/contracts/oracles/DenominatedOracle.sol
@@ -62,9 +62,11 @@ contract DenominatedOracle is IBaseOracle, IDenominatedOracle {
     (uint256 _denominationPriceSourceValue, bool _denominationPriceSourceValidity) =
       denominationPriceSource.getResultWithValidity();
 
-    if (inverted) {
+    if (INVERTED) {
       if (_priceSourceValue == 0) return (0, false);
-      _priceSourceValue = WAD.wdiv(_priceSourceValue);
+      _result = WAD.wmul(_denominationPriceSourceValue).wdiv(_priceSourceValue);
+    } else {
+      _result = _priceSourceValue.wmul(_denominationPriceSourceValue);
     }
 
     _result = _priceSourceValue.wmul(_denominationPriceSourceValue);


### PR DESCRIPTION
potential loss of precision 

For example, for an ETH/HAI price of approximately 3000*1e18, the ideal calculation for the inverted price should preserve as much precision as possible:
10^18 x 10^18/ (3000 x 10^18) = 333 333 333 333 333.333333...
However, the current implementation first performs the division, which truncates the result and leads to a loss of decimal precision.
Therefore it will it will use this 333 333 333 333 333 instead.

By changing the order of operations theres more precision in the calculation