### PR TITLE
chore: temp license change to force open source verification on OP tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,10 @@
-Copyright (C) 2017 DappHub, LLC
-Copyright (C) 2018 Rain <rainbreak@riseup.net>
-Copyright (C) 2018 Lev Livnev <lev@liv.nev.org.uk>
-Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
-Copyright (C) 2020 Reflexer Labs, INC.
-Copyright (C) 2015-2020 DappHub, LLC
-Copyright (C) 2023 Reflexer Labs, INC.
+MIT License
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+Copyright (c) 2020 Reflexer Labs Inc
+Copyright (c) 2023 Reflexer Labs Inc
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU Affero General Public License for more details.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-You should have received a copy of the GNU Affero General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
OP tool is not recognizing our AGPL 3 license file despite it being supported. Temporarily changing file to force the tool to recognize then will change back.